### PR TITLE
Adapter storage

### DIFF
--- a/contracts/adapters/CharmAdapter.sol
+++ b/contracts/adapters/CharmAdapter.sol
@@ -15,33 +15,33 @@ import {
     IOptionToken,
     IOptionViews
 } from "../interfaces/CharmInterface.sol";
-import {
-    InstrumentStorageV1,
-    InstrumentStorageV2,
-    InstrumentStorageV3
-} from "../storage/InstrumentStorage.sol";
+import {AdapterStorage} from "../storage/AdapterStorage.sol";
 import {IWETH} from "../interfaces/IWETH.sol";
 import {UniERC20} from "../lib/UniERC20.sol";
 
-contract CharmAdapter is IProtocolAdapter, InstrumentStorageV1, InstrumentStorageV2, InstrumentStorageV3{
+contract CharmAdapter is IProtocolAdapter {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
     using UniERC20 for IERC20;
 
     IOptionFactory public immutable optionFactory;
     IOptionViews public immutable optionViews;
+    AdapterStorage public immutable adapterStorage;
 
     string private constant _name = "CHARM";
     bool private constant _nonFungible = false;
 
     constructor(
         address _optionFactory,
-        address _optionViews
+        address _optionViews,
+        address _adapterStorage
     ) {
         require(_optionFactory != address(0), "!_optionFactory");
         require(_optionViews != address(0), "!_optionViews");
+        require(_adapterStorage!=address(0),"!_adapterStorage");
         optionFactory = IOptionFactory(_optionFactory);
         optionViews = IOptionViews(_optionViews);
+        adapterStorage = AdapterStorage(_adapterStorage);
     }
 
     receive() external payable {}

--- a/contracts/instruments/RibbonVolatility.sol
+++ b/contracts/instruments/RibbonVolatility.sol
@@ -9,7 +9,6 @@ import {DSMath} from "../lib/DSMath.sol";
 import {
     InstrumentStorageV1,
     InstrumentStorageV2,
-    InstrumentStorageV3,
     Venues
 } from "../storage/InstrumentStorage.sol";
 import {
@@ -20,7 +19,7 @@ import {IRibbonFactory} from "../interfaces/IRibbonFactory.sol";
 import {ProtocolAdapter} from "../adapters/ProtocolAdapter.sol";
 import {Ownable} from "../lib/Ownable.sol";
 
-contract RibbonVolatility is DSMath, InstrumentStorageV1, InstrumentStorageV2, InstrumentStorageV3 {
+contract RibbonVolatility is DSMath, InstrumentStorageV1, InstrumentStorageV2 {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
     using ProtocolAdapter for IProtocolAdapter;

--- a/contracts/storage/AdapterStorage.sol
+++ b/contracts/storage/AdapterStorage.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.7.2;
+pragma experimental ABIEncoderV2;
+
+import {
+    Initializable
+} from "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol";
+import {IRibbonFactory} from "../interfaces/IRibbonFactory.sol";
+
+contract AdapterStorageV1 {
+    struct OptionType {
+        bool isLongToken;
+        uint256 strikeIndex;
+    }
+
+    mapping(bytes32 => address) internal _idToAddress;
+    mapping(address => OptionType) internal _addressToOptionType;
+    mapping(address => bool) internal _seenMarket;
+}
+
+contract AdapterStorage is Initializable, AdapterStorageV1 {
+    IRibbonFactory public immutable factory;
+
+    constructor(address _factory) {
+        require(_factory != address(0), "!_factory");
+        factory = IRibbonFactory(_factory);
+    }
+
+    function initialize() external initializer {}
+
+    function setIdToAddress(bytes32 id, address option)
+        external
+        onlyInstrument
+    {
+        _idToAddress[id] = option;
+    }
+
+    function setAddressToOptionType(
+        address option,
+        OptionType calldata optionType
+    ) external onlyInstrument {
+        _addressToOptionType[option] = optionType;
+    }
+
+    function setSeenMarket(address optionMarket, bool seen)
+        external
+        onlyInstrument
+    {
+        _seenMarket[optionMarket] = seen;
+    }
+
+    function idToAddress(bytes32 id) external view returns (address) {
+        return _idToAddress[id];
+    }
+
+    function addressToOptionType(address option)
+        external
+        view
+        returns (OptionType memory)
+    {
+        return _addressToOptionType[option];
+    }
+
+    function seenMarket(address optionMarket) external view returns (bool) {
+        return _seenMarket[optionMarket];
+    }
+
+    modifier onlyInstrument {
+        require(factory.isInstrument(msg.sender), "!instrument");
+        _;
+    }
+}

--- a/contracts/storage/AdapterStorage.sol
+++ b/contracts/storage/AdapterStorage.sol
@@ -7,14 +7,17 @@ import {
 } from "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol";
 import {IRibbonFactory} from "../interfaces/IRibbonFactory.sol";
 
-contract AdapterStorageV1 {
-    struct OptionType {
+library AdapterStorageTypes {
+    struct CharmOptionType {
         bool isLongToken;
         uint256 strikeIndex;
     }
+}
 
+contract AdapterStorageV1 {
     mapping(bytes32 => address) internal _idToAddress;
-    mapping(address => OptionType) internal _addressToOptionType;
+    mapping(address => AdapterStorageTypes.CharmOptionType)
+        internal _addressToOptionType;
     mapping(address => bool) internal _seenMarket;
 }
 
@@ -37,7 +40,7 @@ contract AdapterStorage is Initializable, AdapterStorageV1 {
 
     function setAddressToOptionType(
         address option,
-        OptionType calldata optionType
+        AdapterStorageTypes.CharmOptionType calldata optionType
     ) external onlyInstrument {
         _addressToOptionType[option] = optionType;
     }
@@ -56,7 +59,7 @@ contract AdapterStorage is Initializable, AdapterStorageV1 {
     function addressToOptionType(address option)
         external
         view
-        returns (OptionType memory)
+        returns (AdapterStorageTypes.CharmOptionType memory)
     {
         return _addressToOptionType[option];
     }

--- a/contracts/storage/InstrumentStorage.sol
+++ b/contracts/storage/InstrumentStorage.sol
@@ -72,14 +72,3 @@ contract InstrumentStorageV2 {
         return instrumentPositions[account][positionID];
     }
 }
-
-contract InstrumentStorageV3 {
-  struct OptionType {
-      bool isLongToken;
-      uint256 strikeIndex;
-  }
-
-  mapping(bytes32 => address) internal idToAddress;
-  mapping(address => OptionType) internal addressToOptionType;
-  mapping(address => bool) internal seenMarket;
-}


### PR DESCRIPTION
This is a change to how we think about storage with ProtocolAdapters. [Previously I suggested](https://github.com/ribbon-finance/structured-products/pull/86#discussion_r592931705) that we have the Adapters inherit the same storage layout as the Instruments like `InstrumentStorageV2` and so on.

But there are a few problems with this approach:
- There is effectively no separation of storage between instruments and adapters
- The new vault contracts will have to inherit the storage layout of both instruments and adapters which will make the situation very hairy
- We need a single source of truth for adapter-specific states, it does not make sense to store adapter states on every single instance of Instrument contracts

Some initial thoughts on issues that may arise:
- Right now we limit the write functions like `setIdToAddress` to instruments only. But what if an attacker took control of an instrument contract? They would be able to alter the state across multiple adapters, effectively infecting all our instruments.
