### PR TITLE
Scheduled withdrawal feature

### DIFF
--- a/contracts/instruments/RibbonThetaVault.sol
+++ b/contracts/instruments/RibbonThetaVault.sol
@@ -291,16 +291,15 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
      * @param shares is the number of shares to be withdrawn in the future.
      */
     function withdrawLater(uint256 shares) external nonReentrant {
-        uint256 _withdrawCounter = withdrawCounter.add(1);
         require(shares > 0, "!shares");
         require(
-            scheduledWithdrawals[msg.sender][_withdrawCounter] == 0,
+            scheduledWithdrawals[msg.sender] == 0,
             "Scheduled withdrawal already exists"
         );
-        withdrawCounter = _withdrawCounter;
-        queuedWithdrawShares = queuedWithdrawShares.add(shares);
+        require(balanceOf(msg.sender) >= shares, "insufficient shares");
 
-        scheduledWithdrawals[msg.sender][_withdrawCounter] = shares;
+        queuedWithdrawShares = queuedWithdrawShares.add(shares);
+        scheduledWithdrawals[msg.sender] = shares;
 
         emit ScheduleWithdraw(msg.sender, _withdrawCounter, shares);
     }
@@ -313,10 +312,10 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
         external
         nonReentrant
     {
-        uint256 withdrawShares = scheduledWithdrawals[msg.sender][withdrawID];
+        uint256 withdrawShares = scheduledWithdrawals[msg.sender];
         require(withdrawShares > 0, "Scheduled withdrawal not found");
 
-        scheduledWithdrawals[msg.sender][withdrawID] = 0;
+        scheduledWithdrawals[msg.sender] = 0;
         queuedWithdrawShares = queuedWithdrawShares.sub(withdrawShares);
         uint256 withdrawAmount = _withdraw(withdrawShares);
 

--- a/contracts/instruments/RibbonThetaVault.sol
+++ b/contracts/instruments/RibbonThetaVault.sol
@@ -274,10 +274,13 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
      * @param share is the number of vault shares to be burned
      */
     function _withdraw(uint256 share) private returns (uint256) {
-        availableToWithdraw = balanceOf(msg.sender).sub(
-            scheduledWithdrawals[msg.sender]
-        );
-        require(availableToWithdraw >= share, "Insufficient shares");
+        uint256 scheduled = scheduledWithdrawals[msg.sender];
+        if (scheduled > 0) {
+            require(
+                balanceOf(msg.sender).sub(scheduled) >= share,
+                "Insufficient shares"
+            );
+        }
 
         (uint256 amountAfterFee, uint256 feeAmount) =
             withdrawAmountWithShares(share);

--- a/contracts/instruments/RibbonThetaVault.sol
+++ b/contracts/instruments/RibbonThetaVault.sol
@@ -314,7 +314,7 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
         nonReentrant
     {
         uint256 withdrawShares = scheduledWithdrawals[msg.sender][withdrawID];
-        require(withdrawShares != 0, "Scheduled withdrawal not found");
+        require(withdrawShares > 0, "Scheduled withdrawal not found");
 
         scheduledWithdrawals[msg.sender][withdrawID] = 0;
         queuedWithdrawShares = queuedWithdrawShares.sub(withdrawShares);

--- a/contracts/instruments/RibbonThetaVault.sol
+++ b/contracts/instruments/RibbonThetaVault.sol
@@ -295,7 +295,7 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
             scheduledWithdrawals[msg.sender] == 0,
             "Scheduled withdrawal already exists"
         );
-        require(balanceOf(msg.sender) >= shares, "insufficient shares");
+        require(balanceOf(msg.sender) >= shares, "Insufficient shares");
 
         queuedWithdrawShares = queuedWithdrawShares.add(shares);
         scheduledWithdrawals[msg.sender] = shares;

--- a/contracts/instruments/RibbonThetaVault.sol
+++ b/contracts/instruments/RibbonThetaVault.sol
@@ -296,9 +296,9 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
             "Scheduled withdrawal already exists"
         );
 
-        _transfer(msg.sender, address(this), shares);
         scheduledWithdrawals[msg.sender] = shares;
         queuedWithdrawShares = queuedWithdrawShares.add(shares);
+        _transfer(msg.sender, address(this), shares);
 
         emit ScheduleWithdraw(msg.sender, shares);
     }

--- a/contracts/instruments/RibbonThetaVault.sol
+++ b/contracts/instruments/RibbonThetaVault.sol
@@ -71,11 +71,10 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
 
     event CapSet(uint256 oldCap, uint256 newCap, address manager);
 
-    event ScheduleWithdraw(address account, uint256 withdrawID, uint256 shares);
+    event ScheduleWithdraw(address account, uint256 shares);
 
     event ScheduledWithdrawCompleted(
         address account,
-        uint256 withdrawID,
         uint256 amount
     );
 
@@ -301,14 +300,13 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
         queuedWithdrawShares = queuedWithdrawShares.add(shares);
         scheduledWithdrawals[msg.sender] = shares;
 
-        emit ScheduleWithdraw(msg.sender, _withdrawCounter, shares);
+        emit ScheduleWithdraw(msg.sender, shares);
     }
 
     /**
      * @notice Closes the scheduled withdrawal and withdraws to msg.sender.
-     * @param withdrawID is the ID used to identify the scheduled withdrawal.
      */
-    function completeScheduledWithdrawal(uint256 withdrawID)
+    function completeScheduledWithdrawal()
         external
         nonReentrant
     {
@@ -319,7 +317,7 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
         queuedWithdrawShares = queuedWithdrawShares.sub(withdrawShares);
         uint256 withdrawAmount = _withdraw(withdrawShares);
 
-        emit ScheduledWithdrawCompleted(msg.sender, withdrawID, withdrawAmount);
+        emit ScheduledWithdrawCompleted(msg.sender, withdrawAmount);
 
         if (asset == WETH) {
             IWETH(WETH).withdraw(withdrawAmount);

--- a/contracts/instruments/RibbonThetaVault.sol
+++ b/contracts/instruments/RibbonThetaVault.sol
@@ -295,7 +295,6 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
             scheduledWithdrawals[msg.sender] == 0,
             "Scheduled withdrawal already exists"
         );
-        require(balanceOf(msg.sender) >= shares, "Insufficient shares");
 
         _transfer(msg.sender, address(this), shares);
         scheduledWithdrawals[msg.sender] = shares;

--- a/contracts/instruments/RibbonThetaVault.sol
+++ b/contracts/instruments/RibbonThetaVault.sol
@@ -71,7 +71,7 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
 
     event CapSet(uint256 oldCap, uint256 newCap, address manager);
 
-    event ScheduleWithdraw(address account, uint256 withdrawID, uint256 amount);
+    event ScheduleWithdraw(address account, uint256 withdrawID, uint256 shares);
 
     event ScheduledWithdrawCompleted(
         address account,
@@ -301,6 +301,8 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
         queuedWithdrawShares = queuedWithdrawShares.add(shares);
 
         scheduledWithdrawals[msg.sender][_withdrawCounter] = shares;
+
+        emit ScheduleWithdraw(msg.sender, _withdrawCounter, shares);
     }
 
     /**
@@ -317,6 +319,8 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
         scheduledWithdrawals[msg.sender][withdrawID] = 0;
         queuedWithdrawShares = queuedWithdrawShares.sub(withdrawShares);
         uint256 withdrawAmount = _withdraw(withdrawShares);
+
+        emit ScheduledWithdrawCompleted(msg.sender, withdrawID, withdrawAmount);
 
         if (asset == WETH) {
             IWETH(WETH).withdraw(withdrawAmount);

--- a/contracts/instruments/RibbonThetaVault.sol
+++ b/contracts/instruments/RibbonThetaVault.sol
@@ -296,11 +296,11 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
             "Scheduled withdrawal already exists"
         );
 
+        emit ScheduleWithdraw(msg.sender, shares);
+
         scheduledWithdrawals[msg.sender] = shares;
         queuedWithdrawShares = queuedWithdrawShares.add(shares);
         _transfer(msg.sender, address(this), shares);
-
-        emit ScheduleWithdraw(msg.sender, shares);
     }
 
     /**
@@ -319,6 +319,9 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
         (uint256 amountAfterFee, uint256 feeAmount) =
             withdrawAmountWithShares(withdrawShares);
 
+        emit Withdraw(msg.sender, amountAfterFee, withdrawShares, feeAmount);
+        emit ScheduledWithdrawCompleted(msg.sender, amountAfterFee);
+
         _burn(address(this), withdrawShares);
         IERC20(asset).safeTransfer(feeRecipient, feeAmount);
         if (asset == WETH) {
@@ -328,8 +331,6 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
         } else {
             IERC20(asset).safeTransfer(msg.sender, amountAfterFee);
         }
-
-        emit ScheduledWithdrawCompleted(msg.sender, amountAfterFee);
     }
 
     /**

--- a/contracts/instruments/RibbonThetaVault.sol
+++ b/contracts/instruments/RibbonThetaVault.sol
@@ -73,10 +73,7 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
 
     event ScheduleWithdraw(address account, uint256 shares);
 
-    event ScheduledWithdrawCompleted(
-        address account,
-        uint256 amount
-    );
+    event ScheduledWithdrawCompleted(address account, uint256 amount);
 
     /**
      * @notice Initializes the contract with immutable variables
@@ -306,10 +303,7 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
     /**
      * @notice Burns user's locked tokens and withdraws assets to msg.sender.
      */
-    function completeScheduledWithdrawal()
-        external
-        nonReentrant
-    {
+    function completeScheduledWithdrawal() external nonReentrant {
         uint256 withdrawShares = scheduledWithdrawals[msg.sender];
         require(withdrawShares > 0, "Scheduled withdrawal not found");
 
@@ -334,7 +328,8 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
     }
 
     /**
-     * @notice Sets the next option the vault will be shorting, and closes the existing short. This allows all the users to withdraw if the next option is malicious.
+     * @notice Sets the next option the vault will be shorting, and closes the existing short.
+     *         This allows all the users to withdraw if the next option is malicious.
      */
     function commitAndClose(
         ProtocolAdapterTypes.OptionTerms calldata optionTerms

--- a/contracts/storage/OptionsVaultStorage.sol
+++ b/contracts/storage/OptionsVaultStorage.sol
@@ -50,10 +50,21 @@ contract OptionsVaultStorageV1 is
     address public feeRecipient;
 }
 
+contract OptionsVaultStorageV2 {
+    // Amount locked for scheduled withdrawals;
+    uint256 public queuedWithdrawShares;
+
+    // Counter used to identify scheduled withdrawals
+    uint256 public withdrawCounter;
+
+    // Mapping to store the scheduled withdrawals (address => (withdrawCounter => withdrawAmount))
+    mapping(address => mapping(uint256 => uint256)) scheduledWithdrawals;
+}
+
 // We are following Compound's method of upgrading new contract implementations
 // When we need to add new storage variables, we create a new version of OptionsVaultStorage
 // e.g. OptionsVaultStorageV<versionNumber>, so finally it would look like
 // contract OptionsVaultStorage is OptionsVaultStorageV1, OptionsVaultStorageV2
-contract OptionsVaultStorage is OptionsVaultStorageV1 {
+contract OptionsVaultStorage is OptionsVaultStorageV1, OptionsVaultStorageV2 {
 
 }

--- a/contracts/storage/OptionsVaultStorage.sol
+++ b/contracts/storage/OptionsVaultStorage.sol
@@ -54,8 +54,8 @@ contract OptionsVaultStorageV2 {
     // Amount locked for scheduled withdrawals;
     uint256 public queuedWithdrawShares;
 
-    // Mapping to store the scheduled withdrawals (address => (withdrawCounter => withdrawAmount))
-    mapping(address => mapping(uint256 => uint256)) scheduledWithdrawals;
+    // Mapping to store the scheduled withdrawals (address => withdrawAmount)
+    mapping(address => uint256) scheduledWithdrawals;
 }
 
 // We are following Compound's method of upgrading new contract implementations

--- a/contracts/storage/OptionsVaultStorage.sol
+++ b/contracts/storage/OptionsVaultStorage.sol
@@ -54,9 +54,6 @@ contract OptionsVaultStorageV2 {
     // Amount locked for scheduled withdrawals;
     uint256 public queuedWithdrawShares;
 
-    // Counter used to identify scheduled withdrawals
-    uint256 public withdrawCounter;
-
     // Mapping to store the scheduled withdrawals (address => (withdrawCounter => withdrawAmount))
     mapping(address => mapping(uint256 => uint256)) scheduledWithdrawals;
 }

--- a/contracts/storage/OptionsVaultStorage.sol
+++ b/contracts/storage/OptionsVaultStorage.sol
@@ -55,7 +55,7 @@ contract OptionsVaultStorageV2 {
     uint256 public queuedWithdrawShares;
 
     // Mapping to store the scheduled withdrawals (address => withdrawAmount)
-    mapping(address => uint256) scheduledWithdrawals;
+    mapping(address => uint256) public scheduledWithdrawals;
 }
 
 // We are following Compound's method of upgrading new contract implementations

--- a/test/RibbonThetaVault.js
+++ b/test/RibbonThetaVault.js
@@ -2577,7 +2577,7 @@ function behavesLikeRibbonOptionsVault(params) {
       });
 
       it("completeScheduledWithdraw behaves as expected for valid scheduled withdraw", async function () {
-        var balanceBeforeWithdraw;
+        let balanceBeforeWithdraw;
         const depositAmount = BigNumber.from("200000000000");
         await depositIntoVault(
           params.collateralAsset,
@@ -2588,8 +2588,6 @@ function behavesLikeRibbonOptionsVault(params) {
         await this.vault.withdrawLater(BigNumber.from("100000000000"));
 
         await this.rollToNextOption();
-
-        var balanceBeforeWithdraw;
 
         if (params.collateralAsset === WETH_ADDRESS) {
           balanceBeforeWithdraw = await provider.getBalance(user);

--- a/test/RibbonThetaVault.js
+++ b/test/RibbonThetaVault.js
@@ -2482,6 +2482,11 @@ function behavesLikeRibbonOptionsVault(params) {
           BigNumber.from("100000000000").toString()
         );
 
+        assert.equal(
+          (await this.vault.scheduledWithdrawals(user)).toString(),
+          BigNumber.from("100000000000").toString()
+        );
+
         // Verify that vault shares were transfer to vault for duration of scheduledWithdraw
         assert.equal(
           (await this.vault.balanceOf(this.vault.address)).toString(),
@@ -2619,6 +2624,12 @@ function behavesLikeRibbonOptionsVault(params) {
         await expect(tx)
           .to.emit(this.vault, "ScheduledWithdrawCompleted")
           .withArgs(user, BigNumber.from("99500000000"));
+
+        // Should set the scheduledWithdrawals entry back to 0
+        assert.equal(
+          (await this.vault.scheduledWithdrawals(user)).toString(),
+          BigNumber.from("0").toString()
+        );
 
         assert.equal(
           (await this.assetContract.balanceOf(this.vault.address)).toString(),


### PR DESCRIPTION
To allow users to exit Theta Vaults with amounts exceeding >10% of the vault, we need a feature that allows users to create a scheduled withdrawal. Each scheduled withdrawal is identified by `(msg.sender, withdrawalID)`.


1. User calls `withdrawLater` to avoid getting their assets being allocated into the next short when the user calls `rollToNextOption`
2. User calls `completeScheduledWithdrawal` to close their scheduled withdrawal.