### PR TITLE
Change migrate logic, remove scheduled withdrawal stuff

### DIFF
--- a/contracts/instruments/RibbonThetaVault.sol
+++ b/contracts/instruments/RibbonThetaVault.sol
@@ -74,7 +74,12 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
 
     event VaultSunset(address replacement);
 
-    event Migrate(address replacement, uint256 shares, uint256 amount);
+    event Migrate(
+        address account,
+        address replacement,
+        uint256 shares,
+        uint256 amount
+    );
 
     /**
      * @notice Initializes the contract with immutable variables
@@ -309,9 +314,12 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
         // Since we want to exclude fees, we add them both together
         withdrawAmount = withdrawAmount.add(feeAmount);
 
-        emit Migrate(address(vault), allShares, withdrawAmount);
+        emit Migrate(msg.sender, address(vault), allShares, withdrawAmount);
+
+        _burn(msg.sender, allShares);
 
         IERC20(asset).safeApprove(address(vault), withdrawAmount);
+
         vault.depositFor(withdrawAmount, msg.sender);
     }
 

--- a/contracts/instruments/RibbonThetaVault.sol
+++ b/contracts/instruments/RibbonThetaVault.sol
@@ -72,11 +72,9 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
 
     event CapSet(uint256 oldCap, uint256 newCap, address manager);
 
-    event ScheduleWithdraw(address account, uint256 shares);
-
-    event ScheduledWithdrawCompleted(address account, uint256 amount);
-
     event VaultSunset(address replacement);
+
+    event Migrate(address replacement, uint256 shares, uint256 amount);
 
     /**
      * @notice Initializes the contract with immutable variables
@@ -159,15 +157,10 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
      * @notice Closes the vault and makes it withdraw only.
      */
     function sunset(address upgradeTo) external onlyOwner {
-        require(!isSunset, "!isSunset");
-        require(replacementVault == address(0), "!replacementVault");
-        require(upgradeTo != address(0), "!upgradeTo");
+        require(address(replacementVault) == address(0), "Already sunset");
+        require(upgradeTo == address(0), "!upgradeTo");
 
-        cap = 0;
-        isSunset = true;
-        instantWithdrawalFee = 0;
-        replacementVault = upgradeTo;
-        IVaultUpgrade = IRibbonV2Vault(upgradeTo);
+        replacementVault = IRibbonV2Vault(upgradeTo);
 
         emit VaultSunset(upgradeTo);
     }
@@ -269,7 +262,7 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
      */
     function withdrawETH(uint256 share) external nonReentrant {
         require(asset == WETH, "!WETH");
-        uint256 withdrawAmount = _withdraw(share, false);
+        uint256 withdrawAmount = _withdraw(share);
 
         IWETH(WETH).withdraw(withdrawAmount);
         (bool success, ) = msg.sender.call{value: withdrawAmount}("");
@@ -281,25 +274,21 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
      * @param share is the number of vault shares to be burned
      */
     function withdraw(uint256 share) external nonReentrant {
-        uint256 withdrawAmount = _withdraw(share, false);
+        uint256 withdrawAmount = _withdraw(share);
         IERC20(asset).safeTransfer(msg.sender, withdrawAmount);
     }
 
     /**
      * @notice Burns vault shares and checks if eligible for withdrawal
      * @param share is the number of vault shares to be burned
-     * @param isScheduled is whether the withdraw was scheduled
      */
-    function _withdraw(uint256 share, bool isScheduled)
-        private
-        returns (uint256)
-    {
+    function _withdraw(uint256 share) private returns (uint256) {
         (uint256 amountAfterFee, uint256 feeAmount) =
             withdrawAmountWithShares(share);
 
         emit Withdraw(msg.sender, amountAfterFee, share, feeAmount);
 
-        _burn(isScheduled ? address(this) : msg.sender, share);
+        _burn(msg.sender, share);
 
         IERC20(asset).safeTransfer(feeRecipient, feeAmount);
 
@@ -307,57 +296,23 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
     }
 
     /**
-     * @notice Lock's users shares for future withdraw and ensures that the new short excludes the scheduled amount.
-     * @param shares is the number of shares to be withdrawn in the future.
-     */
-    function withdrawLater(uint256 shares) external nonReentrant {
-        require(shares > 0, "!shares");
-        require(
-            scheduledWithdrawals[msg.sender] == 0,
-            "Scheduled withdrawal already exists"
-        );
-
-        emit ScheduleWithdraw(msg.sender, shares);
-
-        scheduledWithdrawals[msg.sender] = shares;
-        queuedWithdrawShares = queuedWithdrawShares.add(shares);
-        _transfer(msg.sender, address(this), shares);
-    }
-
-    /**
-     * @notice Burns user's locked tokens and withdraws assets to msg.sender.
-     */
-    function completeScheduledWithdrawal() external nonReentrant {
-        uint256 withdrawShares = scheduledWithdrawals[msg.sender];
-        require(withdrawShares > 0, "Scheduled withdrawal not found");
-
-        scheduledWithdrawals[msg.sender] = 0;
-        queuedWithdrawShares = queuedWithdrawShares.sub(withdrawShares);
-
-        uint256 amountAfterFee = _withdraw(withdrawShares, true);
-
-        emit ScheduledWithdrawCompleted(msg.sender, amountAfterFee);
-
-        if (asset == WETH) {
-            IWETH(WETH).withdraw(amountAfterFee);
-            (bool success, ) = msg.sender.call{value: amountAfterFee}("");
-            require(success, "ETH transfer failed");
-        } else {
-            IERC20(asset).safeTransfer(msg.sender, amountAfterFee);
-        }
-    }
-
-    /**
      * @notice Moves msg.sender's deposited funds to new vault w/o fees
      */
     function migrate() external nonReentrant {
-        require(isSunset, "Not sunset");
-        require(replacementVault != address(0), "Upgrade address not set");
+        IRibbonV2Vault vault = replacementVault;
+        require(address(vault) != address(0), "Not sunset");
 
-        uint256 amountAfterFee = _withdraw(maxWithdrawableShares(), false);
+        uint256 allShares = maxWithdrawableShares();
+        (uint256 withdrawAmount, uint256 feeAmount) =
+            withdrawAmountWithShares(allShares);
 
-        IERC20(asset).safeApprove(replacementVault, amountAfterFee);
-        IVaultUpgrade.depositFor(amountAfterFee, msg.sender);
+        // Since we want to exclude fees, we add them both together
+        withdrawAmount = withdrawAmount.add(feeAmount);
+
+        emit Migrate(address(vault), allShares, withdrawAmount);
+
+        IERC20(asset).safeApprove(address(vault), withdrawAmount);
+        vault.depositFor(withdrawAmount, msg.sender);
     }
 
     /**
@@ -445,7 +400,6 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
             block.timestamp >= nextOptionReadyAt,
             "Cannot roll before delay"
         );
-        require(!isSunset, "Sunset vaults cannot create new positions");
 
         address newOption = nextOption;
         require(newOption != address(0), "No found option");
@@ -454,10 +408,7 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
         nextOption = address(0);
 
         uint256 currentBalance = assetBalance();
-        (uint256 queuedWithdrawAmount, , ) =
-            _withdrawAmountWithShares(queuedWithdrawShares, currentBalance);
-        uint256 freeBalance = currentBalance.sub(queuedWithdrawAmount);
-        uint256 shortAmount = wmul(freeBalance, lockedRatio);
+        uint256 shortAmount = wmul(currentBalance, lockedRatio);
         lockedAmount = shortAmount;
 
         OtokenInterface otoken = OtokenInterface(newOption);
@@ -607,11 +558,9 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
         uint256 withdrawableBalance = assetBalance();
         uint256 total = lockedAmount.add(withdrawableBalance);
         return
-            withdrawableBalance
-                .mul(totalSupply())
-                .div(total)
-                .sub(MINIMUM_SUPPLY)
-                .sub(queuedWithdrawShares);
+            withdrawableBalance.mul(totalSupply()).div(total).sub(
+                MINIMUM_SUPPLY
+            );
     }
 
     /**

--- a/contracts/instruments/RibbonThetaVault.sol
+++ b/contracts/instruments/RibbonThetaVault.sol
@@ -163,7 +163,7 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
      */
     function sunset(address upgradeTo) external onlyOwner {
         require(address(replacementVault) == address(0), "Already sunset");
-        require(upgradeTo == address(0), "!upgradeTo");
+        require(upgradeTo != address(0), "!upgradeTo");
 
         replacementVault = IRibbonV2Vault(upgradeTo);
 

--- a/contracts/instruments/RibbonThetaVault.sol
+++ b/contracts/instruments/RibbonThetaVault.sol
@@ -307,7 +307,7 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
         IRibbonV2Vault vault = replacementVault;
         require(address(vault) != address(0), "Not sunset");
 
-        uint256 allShares = maxWithdrawableShares();
+        uint256 allShares = balanceOf(msg.sender);
         (uint256 withdrawAmount, uint256 feeAmount) =
             withdrawAmountWithShares(allShares);
 

--- a/contracts/instruments/RibbonThetaVault.sol
+++ b/contracts/instruments/RibbonThetaVault.sol
@@ -307,7 +307,7 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
         IRibbonV2Vault vault = replacementVault;
         require(address(vault) != address(0), "Not sunset");
 
-        uint256 allShares = balanceOf(msg.sender);
+        uint256 allShares = maxWithdrawAmount(msg.sender);
         (uint256 withdrawAmount, uint256 feeAmount) =
             withdrawAmountWithShares(allShares);
 
@@ -576,11 +576,7 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
      * @param account is the address of the vault share holder
      * @return amount of `asset` withdrawable from vault, with fees accounted
      */
-    function maxWithdrawAmount(address account)
-        external
-        view
-        returns (uint256)
-    {
+    function maxWithdrawAmount(address account) public view returns (uint256) {
         uint256 maxShares = maxWithdrawableShares();
         uint256 share = balanceOf(account);
         uint256 numShares = min(maxShares, share);

--- a/contracts/interfaces/IERC20Detailed.sol
+++ b/contracts/interfaces/IERC20Detailed.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: MIT
+pragma solidity >=0.7.2;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface IERC20Detailed is IERC20 {

--- a/contracts/lib/CustomSafeERC20.sol
+++ b/contracts/lib/CustomSafeERC20.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.7.2;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/storage/OptionsVaultStorage.sol
+++ b/contracts/storage/OptionsVaultStorage.sol
@@ -51,22 +51,18 @@ contract OptionsVaultStorageV1 is
 }
 
 contract OptionsVaultStorageV2 {
+    // DEPRECATED FOR V2
     // Amount locked for scheduled withdrawals
-    uint256 public queuedWithdrawShares;
+    uint256 private queuedWithdrawShares;
 
+    // DEPRECATED FOR V2
     // Mapping to store the scheduled withdrawals (address => withdrawAmount)
-    mapping(address => uint256) public scheduledWithdrawals;
+    mapping(address => uint256) private scheduledWithdrawals;
 }
 
 contract OptionsVaultStorageV3 {
-    // Amount locked for scheduled withdrawals
-    bool public isSunset;
-
     // Contract address of replacement
-    address public replacementVault;
-
-    // Interfance instance for upgrading
-    IRibbonV2Vault public IVaultUpgrade;
+    IRibbonV2Vault public replacementVault;
 }
 
 // We are following Compound's method of upgrading new contract implementations

--- a/contracts/tests/MockRibbonV2Vault.sol
+++ b/contracts/tests/MockRibbonV2Vault.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.7.2;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/test/RibbonThetaVault.js
+++ b/test/RibbonThetaVault.js
@@ -2836,7 +2836,7 @@ function behavesLikeRibbonOptionsVault(params) {
           this.vault,
           depositAmount
         );
-        await expect(await this.vault.balanceOf(user)).to.be.above(0);
+        expect(await this.vault.balanceOf(user)).to.be.above(0);
 
         await expect(this.vault.migrate()).to.be.revertedWith("Not sunset");
 
@@ -2844,10 +2844,8 @@ function behavesLikeRibbonOptionsVault(params) {
 
         await this.vault.migrate();
 
-        await expect(await this.vault.balanceOf(user)).to.be.equal(
-          minimumAmount
-        );
-        await expect(
+        expect(await this.vault.balanceOf(user)).to.be.equal(minimumAmount);
+        expect(
           await this.assetContract.balanceOf(this.vault.address)
         ).to.be.equal(minimumAmount);
       });

--- a/test/RibbonThetaVault.js
+++ b/test/RibbonThetaVault.js
@@ -2705,6 +2705,8 @@ function behavesLikeRibbonOptionsVault(params) {
     });
 
     describe("#setWithdrawalFee", () => {
+      time.revertToSnapshotAfterTest();
+
       it("reverts when not manager", async function () {
         await expect(
           this.vault.connect(userSigner).setWithdrawalFee(parseEther("0.1"))

--- a/test/RibbonThetaVault.js
+++ b/test/RibbonThetaVault.js
@@ -46,6 +46,7 @@ const TRADER_AFFILIATE = "0xFf98F0052BdA391F8FaD266685609ffb192Bef25";
 const OPTION_DELAY = 60 * 60; // 1 hour
 const LOCKED_RATIO = parseEther("0.9");
 const WITHDRAWAL_BUFFER = parseEther("1").sub(LOCKED_RATIO);
+const WITHDRAWAL_FEE = parseEther("0.005");
 const gasPrice = parseUnits("1", "gwei");
 
 const PUT_OPTION_TYPE = 1;
@@ -2438,260 +2439,6 @@ function behavesLikeRibbonOptionsVault(params) {
       });
     });
 
-    describe("#withdrawLater", () => {
-      time.revertToSnapshotAfterEach();
-
-      it("is within the gas budget", async function () {
-        const depositAmount = BigNumber.from("100000000000");
-        await depositIntoVault(
-          params.collateralAsset,
-          this.vault,
-          depositAmount
-        );
-
-        const res = await this.vault.withdrawLater(
-          BigNumber.from("100000000000")
-        );
-        const receipt = await res.wait();
-        assert.isAtMost(receipt.gasUsed.toNumber(), 90000);
-      });
-
-      it("rejects a withdrawLater of 0 shares", async function () {
-        await expect(
-          this.vault.withdrawLater(BigNumber.from("0"))
-        ).to.be.revertedWith("!shares");
-      });
-
-      it("rejects a scheduled withdrawal when greater than balance", async function () {
-        const depositAmount = BigNumber.from("100000000000");
-        await depositIntoVault(
-          params.collateralAsset,
-          this.vault,
-          depositAmount
-        );
-
-        await expect(
-          this.vault.withdrawLater(BigNumber.from("100000000001"))
-        ).to.be.revertedWith("ERC20: transfer amount exceeds balance");
-      });
-
-      it("accepts a withdrawLater if less than or equal to balance", async function () {
-        const depositAmount = BigNumber.from("100000000000");
-        await depositIntoVault(
-          params.collateralAsset,
-          this.vault,
-          depositAmount
-        );
-
-        const res = await this.vault.withdrawLater(
-          BigNumber.from("100000000000")
-        );
-
-        await expect(res)
-          .to.emit(this.vault, "ScheduleWithdraw")
-          .withArgs(user, BigNumber.from("100000000000"));
-
-        assert.equal(
-          (await this.vault.queuedWithdrawShares()).toString(),
-          BigNumber.from("100000000000").toString()
-        );
-
-        assert.equal(
-          (await this.vault.scheduledWithdrawals(user)).toString(),
-          BigNumber.from("100000000000").toString()
-        );
-
-        // Verify that vault shares were transfer to vault for duration of scheduledWithdraw
-        assert.equal(
-          (await this.vault.balanceOf(this.vault.address)).toString(),
-          BigNumber.from("100000000000").toString()
-        );
-
-        assert.equal(
-          (await this.vault.balanceOf(user)).toString(),
-          BigNumber.from("0").toString()
-        );
-      });
-
-      it("rejects a withdrawLater if a withdrawal is already scheduled", async function () {
-        const depositAmount = BigNumber.from("200000000000");
-        await depositIntoVault(
-          params.collateralAsset,
-          this.vault,
-          depositAmount
-        );
-
-        await this.vault.withdrawLater(BigNumber.from("100000000000"));
-
-        await expect(
-          this.vault.withdrawLater(BigNumber.from("100000000000"))
-        ).to.be.revertedWith("Scheduled withdrawal already exists");
-      });
-
-      it("assets reserved by withdrawLater are not used to short", async function () {
-        const depositAmount = BigNumber.from("200000000000");
-        await depositIntoVault(
-          params.collateralAsset,
-          this.vault,
-          depositAmount
-        );
-
-        const res = await this.vault.withdrawLater(
-          BigNumber.from("100000000000")
-        );
-
-        await expect(res)
-          .to.emit(this.vault, "ScheduleWithdraw")
-          .withArgs(user, BigNumber.from("100000000000"));
-
-        await this.rollToNextOption();
-
-        const vaultBalanceBeforeWithdraw = await this.assetContract.balanceOf(
-          this.vault.address
-        );
-
-        // Queued withdrawals + 10% of available assets set aside
-        assert.equal(
-          vaultBalanceBeforeWithdraw.toString(),
-          BigNumber.from("110000000000").toString()
-        );
-      });
-    });
-
-    describe("completeScheduledWithdrawal", () => {
-      time.revertToSnapshotAfterEach();
-
-      it("is within the gas budget", async function () {
-        const depositAmount = BigNumber.from("100000000000");
-        await depositIntoVault(
-          params.collateralAsset,
-          this.vault,
-          depositAmount
-        );
-
-        await this.vault.withdrawLater(BigNumber.from("1000"));
-
-        const res = await this.vault.completeScheduledWithdrawal();
-
-        const receipt = await res.wait();
-        assert.isAtMost(receipt.gasUsed.toNumber(), 80000);
-      });
-
-      it("rejects a completeScheduledWithdrawal if nothing scheduled", async function () {
-        const depositAmount = BigNumber.from("100000000000");
-        await depositIntoVault(
-          params.collateralAsset,
-          this.vault,
-          depositAmount
-        );
-
-        await expect(
-          this.vault.completeScheduledWithdrawal()
-        ).to.be.revertedWith("Scheduled withdrawal not found");
-      });
-
-      it("completeScheduledWithdraw behaves as expected for valid scheduled withdraw", async function () {
-        let balanceBeforeWithdraw;
-        const depositAmount = BigNumber.from("200000000000");
-        await depositIntoVault(
-          params.collateralAsset,
-          this.vault,
-          depositAmount
-        );
-
-        await this.vault.withdrawLater(BigNumber.from("100000000000"));
-
-        await this.rollToNextOption();
-
-        if (params.collateralAsset === WETH_ADDRESS) {
-          balanceBeforeWithdraw = await provider.getBalance(user);
-        } else {
-          balanceBeforeWithdraw = await this.assetContract.balanceOf(user);
-        }
-        const vaultBalanceBeforeWithdraw = await this.assetContract.balanceOf(
-          this.vault.address
-        );
-
-        // Queued withdrawals + 10% of available assets set aside
-        assert.equal(
-          vaultBalanceBeforeWithdraw.toString(),
-          BigNumber.from("110000000000").toString()
-        );
-
-        const tx = await this.vault.completeScheduledWithdrawal({
-          gasPrice,
-        });
-        const receipt = await tx.wait();
-        const gasFee = gasPrice.mul(receipt.gasUsed);
-
-        await expect(tx)
-          .to.emit(this.vault, "Withdraw")
-          .withArgs(
-            user,
-            BigNumber.from("99500000000"),
-            BigNumber.from("100000000000"),
-            BigNumber.from("500000000")
-          );
-
-        await expect(tx)
-          .to.emit(this.vault, "ScheduledWithdrawCompleted")
-          .withArgs(user, BigNumber.from("99500000000"));
-
-        // Should set the scheduledWithdrawals entry back to 0
-        assert.equal(
-          (await this.vault.scheduledWithdrawals(user)).toString(),
-          BigNumber.from("0").toString()
-        );
-
-        assert.equal(
-          (await this.assetContract.balanceOf(this.vault.address)).toString(),
-          vaultBalanceBeforeWithdraw
-            .sub(BigNumber.from("99500000000"))
-            .toString()
-        );
-
-        // Assert vault shares were burned
-        assert.equal(
-          (await this.vault.balanceOf(this.vault.address)).toString(),
-          BigNumber.from("0").toString()
-        );
-
-        if (params.collateralAsset === WETH_ADDRESS) {
-          assert.equal(
-            (await provider.getBalance(user)).toString(),
-            balanceBeforeWithdraw
-              .sub(gasFee)
-              .add(BigNumber.from("99500000000"))
-              .toString()
-          );
-        } else {
-          assert.equal(
-            (await this.assetContract.balanceOf(user)).toString(),
-            balanceBeforeWithdraw.add(BigNumber.from("99500000000")).toString()
-          );
-        }
-      });
-
-      it("rejects second attempted completeScheduledWithdraw", async function () {
-        const depositAmount = BigNumber.from("200000000000");
-        await depositIntoVault(
-          params.collateralAsset,
-          this.vault,
-          depositAmount
-        );
-
-        await this.vault.withdrawLater(BigNumber.from("100000000000"));
-
-        await this.rollToNextOption();
-
-        await this.vault.completeScheduledWithdrawal();
-
-        await expect(
-          this.vault.completeScheduledWithdrawal()
-        ).to.be.revertedWith("Scheduled withdrawal not found");
-      });
-    });
-
     describe("#withdraw", () => {
       time.revertToSnapshotAfterEach();
 
@@ -3003,116 +2750,72 @@ function behavesLikeRibbonOptionsVault(params) {
 
       it("succeeds when owner", async function () {
         await this.vault.connect(ownerSigner).sunset(this.v2vault.address);
-        assert.equal(await this.vault.isSunset(), true);
 
         assert.equal(await this.vault.replacementVault(), this.v2vault.address);
       });
 
-      it("deposits fail after sunset", async function () {
+      it("deposits still work after sunset", async function () {
         await this.vault.connect(ownerSigner).sunset(this.v2vault.address);
         const depositAmount = BigNumber.from("10000000000");
-        await expect(
-          depositIntoVault(params.collateralAsset, this.vault, depositAmount)
-        ).to.be.revertedWith("Cap exceeded");
+        await depositIntoVault(
+          params.collateralAsset,
+          this.vault,
+          depositAmount
+        );
       });
 
-      if (params.collateralAsset === WETH_ADDRESS) {
-        it("withdraw funds with no fee", async function () {
-          await this.vault.depositETH({ value: parseEther("1") });
-          await this.vault.connect(ownerSigner).sunset(this.v2vault.address);
+      it("withdraw funds with fee", async function () {
+        const depositAmount =
+          params.collateralAsset === WETH_ADDRESS
+            ? parseEther("1")
+            : BigNumber.from("10000000000");
+        const withdrawAmount = depositAmount.sub(params.minimumSupply);
 
-          const startETHBalance = await provider.getBalance(user);
+        await depositIntoVault(
+          params.collateralAsset,
+          this.vault,
+          depositAmount
+        );
+        await this.vault.connect(ownerSigner).sunset(this.v2vault.address);
 
-          const res = await this.vault.withdrawETH(parseEther("0.1"), {
-            gasPrice,
-          });
-          const receipt = await res.wait();
-          const gasFee = gasPrice.mul(receipt.gasUsed);
+        const startAssetBalance = await this.assetContract.balanceOf(user);
 
-          // No fees
-          assert.equal(
-            (await this.assetContract.balanceOf(this.vault.address)).toString(),
-            parseEther("0.9").toString()
+        const res = await this.vault.withdraw(withdrawAmount);
+
+        assert.equal(
+          (await this.assetContract.balanceOf(this.vault.address)).toString(),
+          wmul(withdrawAmount, WITHDRAWAL_FEE)
+            .add(params.minimumSupply)
+            .toString()
+        );
+
+        assert.equal(
+          (await this.assetContract.balanceOf(user))
+            .sub(startAssetBalance)
+            .toString(),
+          wmul(withdrawAmount, parseEther("1").sub(WITHDRAWAL_FEE)).toString()
+        );
+
+        // Share amount is burned
+        assert.equal(
+          (await this.vault.balanceOf(user)).toString(),
+          params.minimumSupply.toString()
+        );
+
+        assert.equal(
+          (await this.vault.totalSupply()).toString(),
+          params.minimumSupply.toString()
+        );
+
+        await expect(res)
+          .to.emit(this.vault, "Withdraw")
+          .withArgs(
+            user,
+            wmul(withdrawAmount, parseEther("1").sub(WITHDRAWAL_FEE)),
+            BigNumber.from(withdrawAmount),
+            wmul(withdrawAmount, WITHDRAWAL_FEE)
           );
-
-          assert.equal(
-            (await provider.getBalance(user))
-              .add(gasFee)
-              .sub(startETHBalance)
-              .toString(),
-            parseEther("0.1").toString()
-          );
-
-          // Share amount is burned
-          assert.equal(
-            (await this.vault.balanceOf(user)).toString(),
-            parseEther("0.9")
-          );
-
-          assert.equal(
-            (await this.vault.totalSupply()).toString(),
-            parseEther("0.9")
-          );
-
-          await expect(res)
-            .to.emit(this.vault, "Withdraw")
-            .withArgs(
-              user,
-              parseEther("0.1"),
-              parseEther("0.1"),
-              parseEther("0.0")
-            );
-        });
-      } else {
-        it("withdraw funds with no fee", async function () {
-          const depositAmount = BigNumber.from("100000000000");
-          await depositIntoVault(
-            params.collateralAsset,
-            this.vault,
-            depositAmount
-          );
-          await this.vault.connect(ownerSigner).sunset(this.v2vault.address);
-
-          const startAssetBalance = await this.assetContract.balanceOf(user);
-
-          const res = await this.vault.withdraw(BigNumber.from("10000000000"), {
-            gasPrice,
-          });
-          await res.wait();
-
-          assert.equal(
-            (await this.assetContract.balanceOf(this.vault.address)).toString(),
-            BigNumber.from("90000000000").toString()
-          );
-
-          assert.equal(
-            (await this.assetContract.balanceOf(user))
-              .sub(startAssetBalance)
-              .toString(),
-            BigNumber.from("10000000000").toString()
-          );
-
-          // Share amount is burned
-          assert.equal(
-            (await this.vault.balanceOf(user)).toString(),
-            BigNumber.from("90000000000")
-          );
-
-          assert.equal(
-            (await this.vault.totalSupply()).toString(),
-            BigNumber.from("90000000000")
-          );
-
-          await expect(res)
-            .to.emit(this.vault, "Withdraw")
-            .withArgs(
-              user,
-              BigNumber.from("10000000000"),
-              BigNumber.from("10000000000"),
-              BigNumber.from("0")
-            );
-        });
-      }
+      });
     });
 
     describe("#migrate", () => {


### PR DESCRIPTION
* We changed the `sunset` logic to avoid breaking weekly operations of v1 vault
* Simplified logic for `migrate` function
* Remove scheduled withdrawal feature from v1 vault