### PR TITLE
Remove redundant Withdraw event

### DIFF
--- a/contracts/instruments/RibbonThetaVault.sol
+++ b/contracts/instruments/RibbonThetaVault.sol
@@ -319,7 +319,6 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
         uint256 receivedShares = IERC20(vault).balanceOf(address(this));
         IERC20(vault).safeTransfer(msg.sender, receivedShares);
 
-        emit Withdraw(msg.sender, withdrawAmount, share, 0);
         emit WithdrawToV1Vault(msg.sender, share, vault, receivedShares);
     }
 


### PR DESCRIPTION
Removed the redundant Withdraw event emitted. It was already emitted in the `_withdraw` function